### PR TITLE
Improve support of Sitecore 9.0

### DIFF
--- a/App_Config/Include/SharedSource.RedirectModule.config
+++ b/App_Config/Include/SharedSource.RedirectModule.config
@@ -1,22 +1,29 @@
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+<!-- 
+  This file was extended with Sitecore 9.0 configuration roles to natively support Sitecore 9.0. 
+  Previous versions of Sitecore such as 8.0, 8.1, 8.2 will ignore these configuration roles notations 
+  so there won't be any difference there, unless Sitecore-Configuration-Roles is installed (8.1.3+) which 
+  supports these notations same way as Sitecore 9.0 OOB.
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
   <sitecore>
     <pipelines>
       <httpRequestBegin>
         <processor type="SharedSource.RedirectModule.Processors.RedirectProcessor,SharedSource.RedirectModule" patch:after="processor[@type='Sitecore.Pipelines.HttpRequest.ItemResolver, Sitecore.Kernel']"/>
       </httpRequestBegin>
 
-      <getContentEditorWarnings>
+      <getContentEditorWarnings role:require="Standalone or ContentManagement">
         <processor type="SharedSource.RedirectModule.Processors.ContentEditorRedirectNotification, SharedSource.RedirectModule" patch:after="processor[@type='Sitecore.Pipelines.GetContentEditorWarnings.Notifications, Sitecore.Kernel']"  />
       </getContentEditorWarnings>
     </pipelines>
 
-    <events>
+    <events role:require="Standalone or ContentManagement">
+      <!-- The feature is only designed for authoring process so it must not be executed on ContentDelivery instance -->
       <event name="item:moved" >
         <handler type="SharedSource.RedirectModule.Handlers.AutoCreateRedirectOnMove, SharedSource.RedirectModule" method="OnItemMoved" patch:after="handler[@type='Sitecore.Globalization.ItemEventHandler']" />
       </event>
     </events>
 
-    <commands>
+    <commands role:require="Standalone or ContentManagement">
       <command name="redirectmanager:delete" type="SharedSource.RedirectModule.Commands.DeleteRedirect,SharedSource.RedirectModule"/>
     </commands>
 

--- a/source/Processors/RedirectProcessor.cs
+++ b/source/Processors/RedirectProcessor.cs
@@ -110,14 +110,8 @@ namespace SharedSource.RedirectModule.Processors
                 // Query portion gets in the way of getting the sitecore item.
                 var pathAndQuery = redirectPath.Split('?');
                 var path = pathAndQuery[0];
-#if (SC82)
-                if (LinkManager.Provider != null &&
-                    LinkManager.Provider.GetDefaultUrlOptions() != null &&
-                    LinkManager.Provider.GetDefaultUrlOptions().EncodeNames)
-#else
                 if (LinkManager.GetDefaultUrlOptions() != null &&
                     LinkManager.GetDefaultUrlOptions().EncodeNames)
-#endif
                 {
                     path = Sitecore.MainUtil.DecodeName(path);
                 }

--- a/source/RedirectModule.csproj
+++ b/source/RedirectModule.csproj
@@ -33,18 +33,6 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SC82|AnyCPU'">
-    <OutputPath>bin\SC82\</OutputPath>
-    <DefineConstants>TRACE;SC82</DefineConstants>
-    <Optimize>true</Optimize>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SC90|AnyCPU'">
-    <OutputPath>bin\SC90\</OutputPath>
-    <DefineConstants>TRACE;SC90</DefineConstants>
-    <Optimize>true</Optimize>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Sitecore.Kernel.NoReferences.8.2.160729\lib\NET452\Sitecore.Kernel.dll</HintPath>

--- a/source/RedirectModule.sln
+++ b/source/RedirectModule.sln
@@ -7,18 +7,12 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		SC82|Any CPU = SC82|Any CPU
-		SC90|Any CPU = SC90|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.SC82|Any CPU.ActiveCfg = SC82|Any CPU
-		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.SC82|Any CPU.Build.0 = SC82|Any CPU
-		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.SC90|Any CPU.ActiveCfg = SC90|Any CPU
-		{EF14CD09-4444-4F57-BCE8-A03EF3C78ECF}.SC90|Any CPU.Build.0 = SC90|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
There are two key changes in this PR:
1. Configuration roles annotations to config files to support Sitecore 9.0 natively in Scaled environments
  It is also compatible with [Sitecore Configuration Roles](https://github.com/Sitecore/Sitecore-configuration-roles)
2. Remove obsolete code in `#if (SC82) ... #else` region because `#else ... #endif` is compatible with both `Sitecore 8.2` and `Sitecore 9.0`