### PR TITLE
Bug fix for item sorting issue

### DIFF
--- a/source/Handlers/AutoCreateRedirectOnMove.cs
+++ b/source/Handlers/AutoCreateRedirectOnMove.cs
@@ -23,6 +23,9 @@ namespace SharedSource.RedirectModule.Handlers
                 Item item = Event.ExtractParameter<Item>(args, 0);
                 ID oldParentID = Event.ExtractParameter<ID>(args, 1);
 
+                // do not create redirect if path has not changed
+                if (oldParentID == item.ParentID) return;
+
                 using (new SecurityDisabler())
                 {
                     CreateRedirectItem(item, item.Database.GetItem(oldParentID));


### PR DESCRIPTION
Currently when an item is moved above or below a sibling by dragging, a redirect is generated that points from the current path to the same path. This creates an unnecessary item as well as a potential redirect loop. 

This one line that I added will prevent a redirect from being generated if the item has been moved but the path has not changed. 