### PR TITLE
This spelling mistake was causing rule-based redirects to be unrespon…

### DIFF
--- a/serialisation/SharedSource.Redirection/Redirect.System.Rules.Definitions.Elements/Redirect Manager/URL string.yml
+++ b/serialisation/SharedSource.Redirection/Redirect.System.Rules.Definitions.Elements/Redirect Manager/URL string.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "ab51c8b2-f0e1-4471-9aae-cc080d774923"
   Hint: Type
-  Value: SharedSource.RedirectModule.Rules.Conditions.URLStringCondtion, SharedSource.RedirectModule
+  Value: SharedSource.RedirectModule.Rules.Conditions.URLStringCondition, SharedSource.RedirectModule
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 300


### PR DESCRIPTION
…sive. Err: The field Type contains a reference to a non-existing type SharedSource.RedirectModule.Rules.Conditions.URLStringCondtion in the assembly: SharedSource.RedirectModule