### PR TITLE
Fix performance issues by changing from SelectSingleItem to GetItem

### DIFF
--- a/source/App_Config/Include/SharedSource/SharedSource.RedirectModule.config
+++ b/source/App_Config/Include/SharedSource/SharedSource.RedirectModule.config
@@ -30,9 +30,7 @@
     <settings>
       <!--  Query Type
             When querying for matches, the module supports different query types.
-            Supported values: 
-              fast  -   The query will use Sitecore's fast query which goes straight to the database. 
-                        Do not use this if you are using multilingual redirects.
+            Supported values:
               query -   The query will use the standard Sitecore query syntax. 
               api   -   The query will locate the redirect root node and then use GetDescendants.
               Default value: api


### PR DESCRIPTION
Fix performance issues by changing from SelectSingleItem to GetItem so that it is cached and doesn't hit the DB every time.

Also remove fast query which is a known performance issue waiting to happen and deprecated feature.